### PR TITLE
Remove ld-options when default paths is enabled.

### DIFF
--- a/arrayfire.cabal
+++ b/arrayfire.cabal
@@ -95,8 +95,7 @@ library
       /opt/arrayfire/include
     extra-lib-dirs:
       /opt/arrayfire/lib
-    ld-options:
-      -Wl,-rpath /opt/arrayfire/lib
+      /opt/arrayfire/lib64
 
 executable main
   hs-source-dirs:


### PR DESCRIPTION
Can't assume `/opt/arrayfire/lib` exists. Just add extra-lib-dirs w/ both `lib64` and `lib`.