### PR TITLE
Fix tests for ArrayFire 3.8.3

### DIFF
--- a/test/ArrayFire/ArithSpec.hs
+++ b/test/ArrayFire/ArithSpec.hs
@@ -2,7 +2,7 @@
 module ArrayFire.ArithSpec where
 
 import ArrayFire  hiding (acos)
-import Prelude    hiding (sqrt, div, and, or, not, isNaN)
+import Prelude    hiding (abs, sqrt, div, and, or, not, isNaN)
 import Test.Hspec
 import Foreign.C
 
@@ -27,10 +27,12 @@ spec =
       matrix @Int (2,2) [[1,1],[1,1]] + matrix @Int (2,2) [[1,1],[1,1]]
         `shouldBe`
            matrix @Int (2,2) [[2,2],[2,2]]
+    -- Exact comparisons of Double don't make sense here, so we just check that the result is
+    -- accurate up to some epsilon.
     it "Should take cubed root" $ do
-      3 `shouldBe` cbrt @Double 27
+      allTrueAll ((abs (3 - cbrt @Double 27)) `lt` 1.0e-14) `shouldBe` (1, 0)
     it "Should take square root" $ do
-      2 `shouldBe` sqrt @Double 4
+      allTrueAll ((abs (2 - sqrt @Double 4)) `lt` 1.0e-14) `shouldBe` (1, 0)
 
     it "Should lte Array" $ do
       2 `le` (3 :: Array Double) `shouldBe` 1

--- a/test/ArrayFire/UtilSpec.hs
+++ b/test/ArrayFire/UtilSpec.hs
@@ -30,8 +30,10 @@ spec =
       A.getSizeOf (Proxy @(Complex Float)) `shouldBe` 8
       A.getSizeOf (Proxy @(Complex Double)) `shouldBe` 16
     it "Should get version" $ do
-      x <- A.getVersion
-      x `shouldBe` (3,8,2)
+      (major, minor, patch) <- A.getVersion
+      major `shouldBe` 3
+      minor `shouldBe` 8
+      patch `shouldSatisfy` (>= 0)
     it "Should get revision" $ do
       x <- A.getRevision
       x `shouldSatisfy` (not . null)


### PR DESCRIPTION
Fixes tests for v3.8.3 of upstream ArrayFire:

 - Do not rely on `==` comparison for cbrt and sqrt tests. Equality comparison is not guaranteed to succeed and in fact fails on some systems (e.g. on Nix on Linux).
 - Allow all `3.8.*` versions.