### PR TITLE
Switch to Nix flakes; make the tests pass with newest ArrayFire

### DIFF
--- a/arrayfire.cabal
+++ b/arrayfire.cabal
@@ -21,6 +21,11 @@ flag disable-default-paths
     default:        False
     manual:         True
 
+flag disable-build-tool-depends
+    description:    When enabled, don't add build-tool-depends fields to the Cabal file. Needed for working inside @nix develop@.
+    default:        False
+    manual:         True
+
 custom-setup
  setup-depends:
    base <5,
@@ -75,8 +80,9 @@ library
     ArrayFire.Internal.Types
     ArrayFire.Internal.Util
     ArrayFire.Internal.Vision
-  build-tool-depends:
-    hsc2hs:hsc2hs
+  if !flag(disable-build-tool-depends)
+    build-tool-depends:
+      hsc2hs:hsc2hs
   extra-libraries:
     af
   c-sources:
@@ -148,8 +154,9 @@ test-suite test
     QuickCheck,
     quickcheck-classes,
     vector
-  build-tool-depends:
-    hspec-discover:hspec-discover
+  if !flag(disable-build-tool-depends)
+    build-tool-depends:
+      hspec-discover:hspec-discover
   default-language:
     Haskell2010
   other-modules:

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+ignore-project: False
+write-ghc-environment-files: always
+tests: True
+test-options: "--color"
+test-show-details: streaming

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,101 @@
+{
+  "nodes": {
+    "arrayfire-nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1692629505,
+        "narHash": "sha256-1JLqp18maO2arcbwzFDpqCPN6nZYGSsLxRmiMf83Dy4=",
+        "owner": "twesterhout",
+        "repo": "arrayfire-nix",
+        "rev": "9480a8162a62604fef11ff15ff52f451257a1298",
+        "type": "github"
+      },
+      "original": {
+        "owner": "twesterhout",
+        "repo": "arrayfire-nix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "arrayfire-nix": "arrayfire-nix",
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692629505,
-        "narHash": "sha256-1JLqp18maO2arcbwzFDpqCPN6nZYGSsLxRmiMf83Dy4=",
+        "lastModified": 1692793973,
+        "narHash": "sha256-6dG41ile3T+6dfRazlcPBdKBarGesswsBpb40Lcf35U=",
         "owner": "twesterhout",
         "repo": "arrayfire-nix",
-        "rev": "9480a8162a62604fef11ff15ff52f451257a1298",
+        "rev": "4236770612b80a3f29adbd8d670f6cea2bc098ba",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1692792214,
+        "narHash": "sha256-voZDQOvqHsaReipVd3zTKSBwN7LZcUwi3/ThMxRZToU=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "1721b3e7c882f75f2301b00d48a2884af8c448ae",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692447944,
-        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
+        "lastModified": 1692638711,
+        "narHash": "sha256-J0LgSFgJVGCC1+j5R2QndadWI1oumusg6hCtYAzLID4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
+        "rev": "91a22f76cd1716f9d0149e8a5c68424bb691de15",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "arrayfire/arrayfire-haskell: ArrayFire Haskell bindings";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
+    arrayfire-nix = {
+      url = "github:twesterhout/arrayfire-nix";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    let
+      src = inputs.nix-filter.lib {
+        root = ./.;
+        include = [
+          "cbits"
+          "exe"
+          "gen"
+          "include"
+          "src"
+          "test"
+          "arrayfire.cabal"
+          "README.md"
+          "CHANGELOG.md"
+          "LICENSE"
+        ];
+      };
+
+      # An overlay that lets us test arrayfire-haskell with different GHC versions
+      arrayfire-haskell-overlay = self: super: {
+        haskell = super.haskell // {
+          packageOverrides = inputs.nixpkgs.lib.composeExtensions super.haskell.packageOverrides
+            (hself: hsuper: {
+              arrayfire = self.haskell.lib.appendConfigureFlags
+                (hself.callCabal2nix "arrayfire" src { af = self.arrayfire; })
+                [ "-f disable-default-paths" ];
+            });
+        };
+      };
+
+      devShell-for = pkgs:
+        let
+          ps = pkgs.haskellPackages;
+        in
+        ps.shellFor {
+          packages = ps: with ps; [ arrayfire ];
+          withHoogle = true;
+          buildInputs = with pkgs; [ ocl-icd ];
+          nativeBuildInputs = with pkgs; with ps; [
+            # Building and testing
+            cabal-install
+            doctest
+            hsc2hs
+            hspec-discover
+            # Language servers
+            haskell-language-server
+            nil
+            # Formatters
+            nixpkgs-fmt
+          ];
+          shellHook = ''
+          '';
+        };
+
+      pkgs-for = system: import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          inputs.arrayfire-nix.overlays.default
+          arrayfire-haskell-overlay
+        ];
+      };
+    in
+    {
+      packages = inputs.flake-utils.lib.eachDefaultSystemMap (system:
+        with (pkgs-for system); {
+          default = haskellPackages.arrayfire;
+          haskell = haskell.packages;
+        });
+
+      devShells = inputs.flake-utils.lib.eachDefaultSystemMap (system: {
+        default = devShell-for (pkgs-for system);
+      });
+
+      overlays.default = arrayfire-haskell-overlay;
+    };
+}

--- a/test/ArrayFire/UtilSpec.hs
+++ b/test/ArrayFire/UtilSpec.hs
@@ -32,7 +32,7 @@ spec =
     it "Should get version" $ do
       (major, minor, patch) <- A.getVersion
       major `shouldBe` 3
-      minor `shouldBe` 8
+      minor `shouldSatisfy` (>= 8)
       patch `shouldSatisfy` (>= 0)
     it "Should get revision" $ do
       x <- A.getRevision


### PR DESCRIPTION
Added nix flake support to the project

- We can now `nix build` to build and test the package, `nix develop` followed by the normal `cabal build` and `cabal test`.
- `nix build .#haskell.ghc96.arrayfire` to build and test with another GHC version (any GHC that is available in Nixpkgs can be used this way).
- `arrayfire-nix` input in the flake provides us with the latest ArrayFire, because the version in Nixpkgs is terribly outdated.


Minor details:

- The `disable-build-tool-depends` flag is needed for working from `nix develop`. Otherwise Cabal won't be able to resolve the plan.