### PR TITLE
Fix joinMany

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
+packages: .
 ignore-project: False
 write-ghc-environment-files: always
 tests: True

--- a/test/ArrayFire/DataSpec.hs
+++ b/test/ArrayFire/DataSpec.hs
@@ -32,3 +32,8 @@ spec =
       constant @(Complex Float) [1] (1.0 :+ 1.0)
         `shouldBe`
           constant @(Complex Float) [1] (1.0 :+ 1.0)
+    it "Should join Arrays along the specified dimension" $ do
+      join 0 (constant @Int [1, 3] 1) (constant @Int [1, 3] 2) `shouldBe` mkArray @Int [2, 3] [1, 2, 1, 2, 1, 2]
+      join 1 (constant @Int [1, 2] 1) (constant @Int [1, 2] 2) `shouldBe` mkArray @Int [1, 4] [1, 1, 2, 2]
+      joinMany 0 [constant @Int [1, 3] 1, constant @Int [1, 3] 2] `shouldBe` mkArray @Int [2, 3] [1, 2, 1, 2, 1, 2]
+      joinMany 1 [constant @Int [1, 2] 1, constant @Int [1, 1] 2, constant @Int [1, 3] 3] `shouldBe` mkArray @Int [1, 6] [1, 1, 2, 3, 3, 3]


### PR DESCRIPTION
Instead of allocating an array of pointers, joinMany was allocating memory for just one pointer. This was making ArrayFire read out of bounds and fail with various errors.

This commit fixes this issue by adding a helper withManyForeignPtr function that acts like withForeignPtr (not unsafeWithForeignPtr!), but for a list of ForeignPtrs.