### PR TITLE
Correct `signum` function according to the Haskell report.

### DIFF
--- a/src/ArrayFire/Orphans.hs
+++ b/src/ArrayFire/Orphans.hs
@@ -32,7 +32,7 @@ instance (Num a, AFType a) => Num (Array a) where
   x + y       = A.add x y
   x * y       = A.mul x y
   abs         = A.abs
-  signum      = A.sign
+  signum x    = A.sign (-x) - A.sign x
   negate arr  = do
     let (w,x,y,z) = A.getDims arr
     A.cast (A.constant @a [w,x,y,z] 0) `A.sub` arr


### PR DESCRIPTION
In Haskell, [`signum x` is defined](https://www.haskell.org/onlinereport/haskell2010/haskellch6.html#x13-1390006.4.4) to be -1 if x is negative, 1 if it is positive, and 0 if x is 0.

(In particular, `signum x * abs x ≡ x` should hold.)

This is different from [ArrayFire's `sign` function](https://arrayfire.org/docs/group__arith__func__sign.htm#gsc.tab=0) (which yields 1 for a negative number and 0 else), but it can be implemented in terms of that function:

- For negative `x`, we have `A.sign (-x) - A.sign x = 0 - 1 = -1`
- For `x=0`, we have `A.sign (-x) - A.sign x = 1 - 1 = 0`
- For positive `x`, we have `A.sign (-x) - A.sign x = 1 - 0 = 1`