### PR TITLE
Export the special `span` value for not-indexing an array dimension.

### DIFF
--- a/src/ArrayFire/Index.hs
+++ b/src/ArrayFire/Index.hs
@@ -44,6 +44,11 @@ index (Array fptr) seqs =
 lookup :: Array a -> Array a -> Int -> Array a
 lookup a b n = op2 a b $ \p x y -> af_lookup p x y (fromIntegral n)
 
+-- | A special value representing the entire axis of an 'Array'.
+span :: Seq
+span = Seq 1 1 0  -- From include/af/seq.h
+                  -- Hard-coded here because FFI cannot import static const values.
+
 -- af_err af_assign_seq( af_array *out, const af_array lhs, const unsigned ndims, const af_seq* const indices, const af_array rhs);
 -- | Calculates 'mean' of 'Array' along user-specified dimension.
 --


### PR DESCRIPTION
The special value [`span`](https://arrayfire.org/docs/namespaceaf.htm#af5c1188f38105afaf8b3f383492a1c9f&gsc.tab=0) is quite important for effective array slicing in ArrayFire, but it was not previously exposed in the Haskell bindings. Indeed, as this is a constant rather than a function it cannot be imported (?) using the FFI, but the same value can simply be hardcoded as a Haskell constant.

Without this export, users could also hard-code it at each use site. But that would result in cryptic code, not to mention unsafe if the definition of `af_span` should ever change. It's certainly better to have it available in the library.