### PR TITLE
Add CI. Generalize `op2` type parameter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,4 @@ jobs:
         run: cabal configure --flags="disable-default-paths disable-build-tool-depends" --extra-include-dirs=$(brew --prefix arrayfire)/include --extra-lib-dirs=$(brew --prefix arrayfire)/lib
 
       - name: Build
-        run: cabal build all
-
-      - name: Test
-        run: cabal install hspec-discover
-        run: cabal test all
+        run: cabal install hspec-discover && cabal build arrayfire

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ArrayFire
+        run: brew install arrayfire
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.8.4'
+          cabal-version: 'latest'
+
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: ~/.cabal/store
+          key: ${{ runner.os }}-cabal-${{ hashFiles('cabal.project', '*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-cabal-
+
+      - name: Configure
+        run: cabal configure --flags="disable-default-paths disable-build-tool-depends" --extra-include-dirs=$(brew --prefix arrayfire)/include --extra-lib-dirs=$(brew --prefix arrayfire)/lib
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test
+        run: cabal test all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,5 @@ jobs:
         run: cabal build all
 
       - name: Test
+        run: cabal install hspec-discover
         run: cabal test all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,5 @@ jobs:
         run: cabal configure --flags="disable-default-paths disable-build-tool-depends" --extra-include-dirs=$(brew --prefix arrayfire)/include --extra-lib-dirs=$(brew --prefix arrayfire)/lib
 
       - name: Build
-        run: cabal install hspec-discover && cabal build arrayfire
+        run: cabal build arrayfire
+

--- a/src/ArrayFire/FFI.hs
+++ b/src/ArrayFire/FFI.hs
@@ -72,7 +72,7 @@ op2
   :: Array b
   -> Array a
   -> (Ptr AFArray -> AFArray -> AFArray -> IO AFErr)
-  -> Array a
+  -> Array c
 {-# NOINLINE op2 #-}
 op2 (Array fptr1) (Array fptr2) op =
   unsafePerformIO $ do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,6 +20,7 @@ instance (A.AFType a, Arbitrary a) => Arbitrary (Array a) where
 
 main :: IO ()
 main = do
+  A.setBackend A.CPU
 --  checks (Proxy :: Proxy (A.Array (A.Complex Float)))
 --  checks (Proxy :: Proxy (A.Array (A.Complex Double)))
 --  checks (Proxy :: Proxy (A.Array Double))


### PR DESCRIPTION
Generalizes `op2` return type so `lookup` can unify.

```
src/ArrayFire/Index.hs:52:22: error: [GHC-25897]
    • Couldn't match type ‘a’ with ‘Int’
      Expected: Array a
        Actual: Array Int
      ‘a’ is a rigid type variable bound by
        the type signature for:
          ArrayFire.Index.lookup :: forall a.
                                    Array a -> Array Int -> Int ->
Array a
        at src/ArrayFire/Index.hs:(44,1)-(51,12)
    • In the second argument of ‘op2’, namely ‘b’
      In the first argument of ‘($)’, namely ‘op2 a b’
      In the expression:
        op2 a b $ \ p x y -> af_lookup p x y (fromIntegral n)
    • Relevant bindings include
        a :: Array a (bound at src/ArrayFire/Index.hs:52:8)
        lookup :: Array a -> Array Int -> Int -> Array a
          (bound at src/ArrayFire/Index.hs:52:1)
   |
52 | lookup a b n = op2 a b $ \p x y -> af_lookup p x y (fromIntegral
n)
   |                      ^
Error: cabal: Failed to build arrayfire-0.7.0.0.
```